### PR TITLE
Ensure that a correct sized byte array is used for the checksum base64 conversion.

### DIFF
--- a/s3adapter/upload.go
+++ b/s3adapter/upload.go
@@ -75,7 +75,10 @@ func (conn *Connection) Upload(oid string, localPath string, callback func(trans
 
 			rawsum := checksummer.Sum32()
 			log.Printf("RawSum: 0x%x", rawsum)
-			checksum := base64.StdEncoding.EncodeToString(big.NewInt(int64(rawsum)).Bytes())
+			bigIntSum := big.NewInt(int64(rawsum))
+			bytesSum := make([]byte, 4)
+			bigIntSum.FillBytes(bytesSum)
+			checksum := base64.StdEncoding.EncodeToString(bytesSum)
 			log.Printf("File checksum: %s", checksum)
 
 			if *ho.ChecksumCRC32C != checksum {


### PR DESCRIPTION
Otherwise invalid checksums were generated and compared.